### PR TITLE
Fix wrong DTPlatformName when copying Info.plist from Release-appletvos folder

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,23 +16,18 @@ xcodebuild -project SwiftOpenCC/SwiftyOpenCC.xcodeproj -target OpenCCBridge -sdk
 xcodebuild -project SwiftOpenCC/SwiftyOpenCC.xcodeproj -target OpenCCBridge -sdk appletvos -arch arm64 -arch arm64e SYMROOT="../build" OTHER_CFLAGS="-fembed-bitcode" BITCODE_GENERATION_MODE=bitcode ONLY_ACTIVE_ARCH=NO 2>&1
 xcodebuild -project SwiftOpenCC/SwiftyOpenCC.xcodeproj -target OpenCCBridge -sdk appletvsimulator -arch i386 -arch x86_64 -arch arm64 SYMROOT="../build" OTHER_CFLAGS="-fembed-bitcode" BITCODE_GENERATION_MODE=bitcode ONLY_ACTIVE_ARCH=NO 2>&1
 
-cp build/Release-appletvos/OpenCCBridge.framework/Info.plist build/Release/OpenCCBridge.framework/.
 /usr/libexec/Plistbuddy -c "Add :CFBundleVersion string '1.0.0'" build/Release/OpenCCBridge.framework/Info.plist
 /usr/libexec/Plistbuddy -c "Set :CFBundleShortVersionString 1.0.0" build/Release/OpenCCBridge.framework/Info.plist
 
-cp build/Release-appletvos/OpenCCBridge.framework/Info.plist build/Release-iphoneos/OpenCCBridge.framework/.
 /usr/libexec/Plistbuddy -c "Add :CFBundleVersion string '1.0.0'" build/Release-iphoneos/OpenCCBridge.framework/Info.plist
 /usr/libexec/Plistbuddy -c "Set :CFBundleShortVersionString 1.0.0" build/Release-iphoneos/OpenCCBridge.framework/Info.plist
 
-cp build/Release-appletvos/OpenCCBridge.framework/Info.plist build/Release-iphonesimulator/OpenCCBridge.framework/.
 /usr/libexec/Plistbuddy -c "Add :CFBundleVersion string '1.0.0'" build/Release-iphonesimulator/OpenCCBridge.framework/Info.plist
 /usr/libexec/Plistbuddy -c "Set :CFBundleShortVersionString 1.0.0" build/Release-iphonesimulator/OpenCCBridge.framework/Info.plist
 
-cp build/Release-appletvos/OpenCCBridge.framework/Info.plist build/Release-appletvos/OpenCCBridge.framework/.
 /usr/libexec/Plistbuddy -c "Add :CFBundleVersion string '1.0.0'" build/Release-appletvos/OpenCCBridge.framework/Info.plist
 /usr/libexec/Plistbuddy -c "Set :CFBundleShortVersionString 1.0.0" build/Release-appletvos/OpenCCBridge.framework/Info.plist
 
-cp build/Release-appletvos/OpenCCBridge.framework/Info.plist build/Release-appletvsimulator/OpenCCBridge.framework/.
 /usr/libexec/Plistbuddy -c "Add :CFBundleVersion string '1.0.0'" build/Release-appletvsimulator/OpenCCBridge.framework/Info.plist
 /usr/libexec/Plistbuddy -c "Set :CFBundleShortVersionString 1.0.0" build/Release-appletvsimulator/OpenCCBridge.framework/Info.plist
 


### PR DESCRIPTION
<img width="720" alt="e" src="https://user-images.githubusercontent.com/97494583/216921769-848b9ec4-8d53-415d-8459-d953665ba911.png">
